### PR TITLE
Make generated snippets configurable, add source maps and change config name to theme-packer.config.js.

### DIFF
--- a/packages/Config/defaults.js
+++ b/packages/Config/defaults.js
@@ -127,6 +127,10 @@ const server = {
 
 const webpack = {
     'webpack.extend': {},
+
+    'webpack.assets.snippets.script-tags': 'base.script-tags.liquid',
+
+    'webpack.assets.snippets.style-tags': 'base.style-tags.liquid',
 };
 
 module.exports = {

--- a/utils/get-entrypoints.js
+++ b/utils/get-entrypoints.js
@@ -1,6 +1,5 @@
 const fs = require('fs');
 const path = require('path');
-const consola = require('consola');
 const Config = require('../packages/Config');
 
 /**
@@ -103,8 +102,6 @@ const getEntrypoints = () => {
             entrypoints[`${entryType}.${name}`] = entryFile;
         });
     });
-
-    consola.info('Entrypoints:', entrypoints);
 
     return entrypoints;
 };

--- a/utils/get-user-config.js
+++ b/utils/get-user-config.js
@@ -3,7 +3,7 @@ const path = require('path');
 
 /** @returns {object} */
 const getUserConfig = () => {
-    const configPath = path.resolve(process.cwd(), 'shopify.config.js');
+    const configPath = path.resolve(process.cwd(), 'theme-packer.config.js');
 
     if (fs.existsSync(configPath)) {
         // eslint-disable-next-line global-require, import/no-dynamic-require

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -44,7 +44,7 @@ module.exports = () => {
             excludeChunks: ['static'],
             filename: path.join(
                 Config.get('paths.theme.dist.snippets'),
-                'includes.script-tags.liquid'
+                Config.get('webpack.assets.snippets.script-tags')
             ),
             inject: false,
             minify: {
@@ -61,7 +61,7 @@ module.exports = () => {
             excludeChunks: ['static'],
             filename: path.join(
                 Config.get('paths.theme.dist.snippets'),
-                'includes.style-tags.liquid'
+                Config.get('webpack.assets.snippets.style-tags')
             ),
             inject: false,
             minify: {
@@ -117,6 +117,14 @@ module.exports = () => {
         });
 
         plugins.push(new webpack.HotModuleReplacementPlugin());
+    }
+
+    if (mode === 'production') {
+        plugins.push(
+            new webpack.DefinePlugin({
+                'process.env.NODE_ENV': JSON.stringify(process.env.NODE_ENV),
+            })
+        );
     }
 
     const config = {
@@ -180,6 +188,8 @@ module.exports = () => {
     };
 
     if (mode === 'production') {
+        config.devtool = 'hidden-source-map';
+
         config.optimization = {
             splitChunks: {
                 chunks: 'initial',
@@ -187,6 +197,8 @@ module.exports = () => {
             },
         };
     } else {
+        config.devtool = 'eval-source-map';
+
         /**
          * @warning This is only a temporary fix.
          * @see {@link https://github.com/webpack/webpack-dev-server/issues/2792 | Related GitHub Issue}


### PR DESCRIPTION
- Make asset snippet names configurable.
- Use DefinePlugin to replace `process.env.NODE_ENV`.
- Add source maps.
- Remove entrypoint logging.
- Change config name to `theme-packer.config.js`.