### PR TITLE
Implement strategies to reduce filename length.

### DIFF
--- a/utils/get-entrypoints.js
+++ b/utils/get-entrypoints.js
@@ -99,7 +99,7 @@ const getEntrypoints = () => {
                 return;
             }
 
-            entrypoints[`${entryType}.${name}`] = entryFile;
+            entrypoints[`${entryType.charAt(0)}.${name}`] = entryFile;
         });
     });
 

--- a/utils/get-entrypoints.js
+++ b/utils/get-entrypoints.js
@@ -1,6 +1,7 @@
 const fs = require('fs');
 const path = require('path');
 const Config = require('../packages/Config');
+const md5 = require('./md5');
 
 /**
  * @param {{[key: string]: string|string[]}} entrypoints
@@ -67,7 +68,7 @@ const isValidTemplate = filename => {
  * getEntrypoints is basically just a rewrite of the
  * {@link https://github.com/Shopify/slate/blob/master/packages/slate-tools/tools/webpack/config/utilities/get-template-entrypoints.js | Slate v1 get-entrypoints utilities}.
  */
-const getEntrypoints = () => {
+const getEntrypoints = (asTemplateNameMap = false) => {
     const entrypoints = {};
 
     const entrypointsMap = {
@@ -99,7 +100,13 @@ const getEntrypoints = () => {
                 return;
             }
 
-            entrypoints[`${entryType.charAt(0)}.${name}`] = entryFile;
+            const hashedName = md5(name).substring(0, 6).toString();
+
+            if (asTemplateNameMap) {
+                entrypoints[hashedName] = name;
+            } else {
+                entrypoints[`${entryType.charAt(0)}.${hashedName}`] = entryFile;
+            }
         });
     });
 

--- a/utils/md5.js
+++ b/utils/md5.js
@@ -1,0 +1,139 @@
+const md5 = string => {
+    const hc = '0123456789abcdef';
+
+    function rh(n) {
+        let j, s = '';
+        for (j = 0; j <= 3; j++) s += hc.charAt((n >> (j * 8 + 4)) & 0x0F) + hc.charAt((n >> (j * 8)) & 0x0F);
+        return s;
+    }
+
+    function ad(x, y) {
+        let l = (x & 0xFFFF) + (y & 0xFFFF);
+        let m = (x >> 16) + (y >> 16) + (l >> 16);
+        return (m << 16) | (l & 0xFFFF);
+    }
+
+    function rl(n, c) {
+        return (n << c) | (n >>> (32 - c));
+    }
+
+    function cm(q, a, b, x, s, t) {
+        return ad(rl(ad(ad(a, q), ad(x, t)), s), b);
+    }
+
+    function ff(a, b, c, d, x, s, t) {
+        return cm((b & c) | ((~b) & d), a, b, x, s, t);
+    }
+
+    function gg(a, b, c, d, x, s, t) {
+        return cm((b & d) | (c & (~d)), a, b, x, s, t);
+    }
+
+    function hh(a, b, c, d, x, s, t) {
+        return cm(b ^ c ^ d, a, b, x, s, t);
+    }
+
+    function ii(a, b, c, d, x, s, t) {
+        return cm(c ^ (b | (~d)), a, b, x, s, t);
+    }
+
+    function sb(x) {
+        let i;
+        let nblk = ((x.length + 8) >> 6) + 1;
+        let blks = new Array(nblk * 16);
+        for (i = 0; i < nblk * 16; i++) blks[i] = 0;
+        for (i = 0; i < x.length; i++) blks[i >> 2] |= x.charCodeAt(i) << ((i % 4) * 8);
+        blks[i >> 2] |= 0x80 << ((i % 4) * 8);
+        blks[nblk * 16 - 2] = x.length * 8;
+        return blks;
+    }
+
+    let i;
+    let a = 1732584193;
+    let b = -271733879;
+    let c = -1732584194;
+    let d = 271733878;
+    let olda;
+    let oldb;
+    let oldc;
+    let oldd;
+    const x = sb(string);
+    for (i = 0; i < x.length; i += 16) {
+        olda = a;
+        oldb = b;
+        oldc = c;
+        oldd = d;
+        a = ff(a, b, c, d, x[i + 0], 7, -680876936);
+        d = ff(d, a, b, c, x[i + 1], 12, -389564586);
+        c = ff(c, d, a, b, x[i + 2], 17, 606105819);
+        b = ff(b, c, d, a, x[i + 3], 22, -1044525330);
+        a = ff(a, b, c, d, x[i + 4], 7, -176418897);
+        d = ff(d, a, b, c, x[i + 5], 12, 1200080426);
+        c = ff(c, d, a, b, x[i + 6], 17, -1473231341);
+        b = ff(b, c, d, a, x[i + 7], 22, -45705983);
+        a = ff(a, b, c, d, x[i + 8], 7, 1770035416);
+        d = ff(d, a, b, c, x[i + 9], 12, -1958414417);
+        c = ff(c, d, a, b, x[i + 10], 17, -42063);
+        b = ff(b, c, d, a, x[i + 11], 22, -1990404162);
+        a = ff(a, b, c, d, x[i + 12], 7, 1804603682);
+        d = ff(d, a, b, c, x[i + 13], 12, -40341101);
+        c = ff(c, d, a, b, x[i + 14], 17, -1502002290);
+        b = ff(b, c, d, a, x[i + 15], 22, 1236535329);
+        a = gg(a, b, c, d, x[i + 1], 5, -165796510);
+        d = gg(d, a, b, c, x[i + 6], 9, -1069501632);
+        c = gg(c, d, a, b, x[i + 11], 14, 643717713);
+        b = gg(b, c, d, a, x[i + 0], 20, -373897302);
+        a = gg(a, b, c, d, x[i + 5], 5, -701558691);
+        d = gg(d, a, b, c, x[i + 10], 9, 38016083);
+        c = gg(c, d, a, b, x[i + 15], 14, -660478335);
+        b = gg(b, c, d, a, x[i + 4], 20, -405537848);
+        a = gg(a, b, c, d, x[i + 9], 5, 568446438);
+        d = gg(d, a, b, c, x[i + 14], 9, -1019803690);
+        c = gg(c, d, a, b, x[i + 3], 14, -187363961);
+        b = gg(b, c, d, a, x[i + 8], 20, 1163531501);
+        a = gg(a, b, c, d, x[i + 13], 5, -1444681467);
+        d = gg(d, a, b, c, x[i + 2], 9, -51403784);
+        c = gg(c, d, a, b, x[i + 7], 14, 1735328473);
+        b = gg(b, c, d, a, x[i + 12], 20, -1926607734);
+        a = hh(a, b, c, d, x[i + 5], 4, -378558);
+        d = hh(d, a, b, c, x[i + 8], 11, -2022574463);
+        c = hh(c, d, a, b, x[i + 11], 16, 1839030562);
+        b = hh(b, c, d, a, x[i + 14], 23, -35309556);
+        a = hh(a, b, c, d, x[i + 1], 4, -1530992060);
+        d = hh(d, a, b, c, x[i + 4], 11, 1272893353);
+        c = hh(c, d, a, b, x[i + 7], 16, -155497632);
+        b = hh(b, c, d, a, x[i + 10], 23, -1094730640);
+        a = hh(a, b, c, d, x[i + 13], 4, 681279174);
+        d = hh(d, a, b, c, x[i + 0], 11, -358537222);
+        c = hh(c, d, a, b, x[i + 3], 16, -722521979);
+        b = hh(b, c, d, a, x[i + 6], 23, 76029189);
+        a = hh(a, b, c, d, x[i + 9], 4, -640364487);
+        d = hh(d, a, b, c, x[i + 12], 11, -421815835);
+        c = hh(c, d, a, b, x[i + 15], 16, 530742520);
+        b = hh(b, c, d, a, x[i + 2], 23, -995338651);
+        a = ii(a, b, c, d, x[i + 0], 6, -198630844);
+        d = ii(d, a, b, c, x[i + 7], 10, 1126891415);
+        c = ii(c, d, a, b, x[i + 14], 15, -1416354905);
+        b = ii(b, c, d, a, x[i + 5], 21, -57434055);
+        a = ii(a, b, c, d, x[i + 12], 6, 1700485571);
+        d = ii(d, a, b, c, x[i + 3], 10, -1894986606);
+        c = ii(c, d, a, b, x[i + 10], 15, -1051523);
+        b = ii(b, c, d, a, x[i + 1], 21, -2054922799);
+        a = ii(a, b, c, d, x[i + 8], 6, 1873313359);
+        d = ii(d, a, b, c, x[i + 15], 10, -30611744);
+        c = ii(c, d, a, b, x[i + 6], 15, -1560198380);
+        b = ii(b, c, d, a, x[i + 13], 21, 1309151649);
+        a = ii(a, b, c, d, x[i + 4], 6, -145523070);
+        d = ii(d, a, b, c, x[i + 11], 10, -1120210379);
+        c = ii(c, d, a, b, x[i + 2], 15, 718787259);
+        b = ii(b, c, d, a, x[i + 9], 21, -343485551);
+        a = ad(a, olda);
+        b = ad(b, oldb);
+        c = ad(c, oldc);
+        d = ad(d, oldd);
+    }
+
+    return rh(a) + rh(b) + rh(c) + rh(d);
+};
+
+module.exports = md5;

--- a/utils/render-asset-snippets.js
+++ b/utils/render-asset-snippets.js
@@ -95,9 +95,14 @@ const getPartialsData = (filename, entrypoints) => {
         .filter(part => !part.startsWith('vendor'));
 
     return fileNameParts.map(partialName => {
-        const [type, ...otherFileNameParts] = partialName.split(
+        const [typeIdentifier, ...otherFileNameParts] = partialName.split(
             entryPartsDelimiter
         );
+
+        const type = {
+            l: 'layout',
+            t: 'templates'
+        }[typeIdentifier];
 
         let parentDirectory;
         if (type === 'templates') {

--- a/utils/render-asset-snippets.js
+++ b/utils/render-asset-snippets.js
@@ -1,4 +1,5 @@
 const path = require('path');
+const { getEntrypoints } = require('./get-entrypoints');
 const Config = require('../packages/Config');
 
 /** @typedef {{[key: string]: string}} Entrypoints */
@@ -61,6 +62,8 @@ const getEntrypointKey = (type, otherFileNameParts) => {
 
 /** @param {ModulePartialData[]} partials */
 const getLiquidConditionsFromPartials = partials => {
+    const realNameMap = getEntrypoints(true);
+
     return partials
         .map(partial => {
             let name = partial.filename;
@@ -68,7 +71,7 @@ const getLiquidConditionsFromPartials = partials => {
                 name = `${partial.parentDirectory}/${name}`;
             }
 
-            return `${partial.type} == '${name}'`;
+            return `${partial.type} == '${realNameMap[name]}'`;
         })
         .join(' or ');
 };

--- a/utils/render-asset-snippets.js
+++ b/utils/render-asset-snippets.js
@@ -71,7 +71,15 @@ const getLiquidConditionsFromPartials = partials => {
                 name = `${partial.parentDirectory}/${name}`;
             }
 
-            return `${partial.type} == '${realNameMap[name]}'`;
+            let partialType = partial.type;
+            let partialName = realNameMap[name];
+
+            if (partial.parentDirectory === 'customers') {
+                partialType = 'template.directory';
+                partialName = partial.parentDirectory;
+            }
+
+            return `${partialType} == '${partialName}'`;
         })
         .join(' or ');
 };


### PR DESCRIPTION
At some point in a project, the number of templates and layouts is going to cause the bundle filenames to become too long, exceeding 255 characters.

Here we've implemented two strategies: 

* the first is shortening the filename type prefixes from `layout` to `l` and `template` to `t`
* secondly the filenames are hashed and the first 6 characters are used in place